### PR TITLE
add read delay to the lib itself

### DIFF
--- a/examples/MD_MSGEQ7_Serial/MD_MSGEQ7_Serial.ino
+++ b/examples/MD_MSGEQ7_Serial/MD_MSGEQ7_Serial.ino
@@ -14,7 +14,7 @@
 // frequency reading the IC data
 #define READ_DELAY  50
 
-MD_MSGEQ7 MSGEQ7(RESET_PIN, STROBE_PIN, DATA_PIN);
+MD_MSGEQ7 MSGEQ7(RESET_PIN, STROBE_PIN, DATA_PIN, READ_DELAY);
 
 void setup() 
 {
@@ -26,15 +26,8 @@ void setup()
 
 void loop() 
 {
-  // only read every READ_DELAY milliseconds
-  static long prevTime = 0;
-  
-  if (millis() - prevTime >= READ_DELAY) 
+  if (MSGEQ7.read())
   {
-    prevTime = millis();
-
-    MSGEQ7.read();
-
     // Serial output
     for (uint8_t i=0; i<MAX_BAND; i++)
     {

--- a/src/MD_MSGEQ7.cpp
+++ b/src/MD_MSGEQ7.cpp
@@ -47,9 +47,12 @@ void MD_MSGEQ7::reset(void)
   delayMicroseconds(72);  // trs = 72 microseconds
 }
 
-void MD_MSGEQ7::read(bool bReset)
+bool MD_MSGEQ7::read(bool bReset)
 // Read all the values from the IC and store in local object array
 {
+	if(millis() - _lastRead < _readDelay)
+		return false;
+
 	if (bReset) reset(); 	// reset the IC if required
 
 	// read all MAX_BAND channels 
@@ -68,6 +71,8 @@ void MD_MSGEQ7::read(bool bReset)
     
     delayMicroseconds(18);
   }
+	_lastRead = millis();
+	return true;
 }
 
 uint16_t MD_MSGEQ7::get(uint8_t band)

--- a/src/MD_MSGEQ7.h
+++ b/src/MD_MSGEQ7.h
@@ -81,8 +81,8 @@ public:
    * \param strobePin	Arduino output for strobing the device during read.
    * \param dataPin		Arduino input where data gets read from the IC.
    */
- 	MD_MSGEQ7(uint8_t resetPin, uint8_t strobePin, uint8_t dataPin):
-		_resetPin(resetPin), _strobePin(strobePin), _dataPin(dataPin) 
+ 	MD_MSGEQ7(uint8_t resetPin, uint8_t strobePin, uint8_t dataPin, uint8_t readDelay):
+		_resetPin(resetPin), _strobePin(strobePin), _dataPin(dataPin) , _readDelay(readDelay)
 		{};
 
   /** 
@@ -122,9 +122,9 @@ public:
 	 * is used to suppress a reset before the read - default is to reset.
 	 * 
    * \param bReset	enables a device reset prior to read if true, disables if false.
-   * \return No Return value.
+   * \return True if read was successful
    */
-	void read(bool bReset = true);
+	bool read(bool bReset = true);
 	
   /**
    * Get a specific value from the data read.
@@ -145,6 +145,10 @@ private:
 	uint8_t _resetPin;
 	uint8_t _strobePin;
 	uint8_t _dataPin;
+
+  // Read delay settings
+  uint8_t _readDelay;
+  uint32_t _lastRead;
 
 	// array of all input values
 	uint16_t _data[MAX_BAND];


### PR DESCRIPTION
## Proposed changes
This PR modifies current functionality to abstract the user about read timing details.  
It improves the abstraction layer of the library by removing the delay between reads to the library itself. It is good for newbies.

## Types of changes
What types of changes does your code introduce?
[ ] Bugfix (non-breaking change which fixes an issue)
[x] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Your Environment
**Library Version:** 1.1.0 
**Arduino IDE version:** 2.3.2 
**Hardware model/type:** Uno 
**OS and Version:** Windows 10 22H 

## Checklist
[x] Code compiles correctly/with no errors
[ ] I have added tests that prove my fix is effective or that my feature works
[ ] I have added or extended necessary documentation (if appropriate)
[x] Any dependent changes have been merged and published in downstream modules